### PR TITLE
Added parameter reader helper func

### DIFF
--- a/violetear.go
+++ b/violetear.go
@@ -143,6 +143,19 @@ func (v *Router) AddRegex(name, regex string) error {
 	return v.dynamicRoutes.Set(name, regex)
 }
 
+// GetParam returns a value for the parameter set in path
+// and described via a regexp on Router initialization
+// The method is using the context in order to retrieve the value,
+// thus is only applicable for go >= 1.7
+func GetParam(name string, r *http.Request) string {
+	params := r.Context().Value(ParamsKey).(Params)
+	if len(params) == 0 {
+		return ""
+	}
+
+	return params[":"+name].(string)
+}
+
 // MethodNotAllowed default handler for 405
 func (v *Router) MethodNotAllowed() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/violetear.go
+++ b/violetear.go
@@ -153,7 +153,7 @@ func (v *Router) MethodNotAllowed() http.HandlerFunc {
 	})
 }
 
-// ServerHTTP dispatches the handler registered in the matched path
+// ServeHTTP dispatches the handler registered in the matched path
 func (v *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	lw := NewResponseWriter(w)


### PR DESCRIPTION
Hi, @nbari. Since we end up rewriting the same piece of code in order to access parameter values, I decided to make this PR. Let me know what you think and if you agree with the solution I will update the README file as well.

Example:

```go
// Define parameter via regexp
router := violetear.New()
router.AddRegex(":language", `^\w+$`)

// Read parameter in your handler
func HandleLanguage(w http.ResponseWriter, r *http.Request) {
    language := violetear.GetParam("language")
    fmt.Fprintf(w, "your language is: %s", language)
}
```